### PR TITLE
fix(security): SQL 識別子の扱いと LIKE ワイルドカードのエスケープを修正

### DIFF
--- a/database.php
+++ b/database.php
@@ -68,6 +68,52 @@ $tableSchema = [
 // -----------------------------------------------------------------------------
 
 /**
+ * テーブル名・カラム名として安全に使える文字列かを検証し、バッククォートで囲みます。
+ * Validates an identifier and wraps it in backticks.
+ *
+ * mysqli::real_escape_string() は識別子のエスケープには使えない。
+ * エスケープするのは ' " \ NUL などであって、識別子の区切り文字である
+ * バッククォートは対象外なので、
+ *
+ *     `t` (SELECT ...) -- `
+ *
+ * のような値を渡されるとクォートの外へ抜け出せてしまう。
+ * 識別子はバインドできないため、使ってよい文字を限定するしかない。
+ *
+ * @param string $identifier 検証対象のテーブル名またはカラム名
+ * @return string バッククォートで囲んだ識別子
+ * @throws InvalidArgumentException 使用できない文字が含まれる場合
+ */
+function quoteIdentifier(string $identifier): string
+{
+    if (!preg_match('/\A[A-Za-z_][A-Za-z0-9_]{0,63}\z/', $identifier)) {
+        throw new InvalidArgumentException("Invalid SQL identifier: {$identifier}");
+    }
+
+    return '`' . $identifier . '`';
+}
+
+/**
+ * カラムの型定義として安全な文字列かを検証します。
+ * Validates a column type definition.
+ *
+ * 型定義は CREATE TABLE へそのまま埋め込まれるため、
+ * ここを通る文字列は DDL の一部になる。想定される字句だけを許可する。
+ *
+ * @param string $type 検証対象の型定義 (e.g. 'VARCHAR(255) NOT NULL')
+ * @return string 検証済みの型定義
+ * @throws InvalidArgumentException 使用できない文字が含まれる場合
+ */
+function validateColumnType(string $type): string
+{
+    if (!preg_match('/\A[A-Za-z0-9_(),\' ]+\z/', $type)) {
+        throw new InvalidArgumentException("Invalid column type: {$type}");
+    }
+
+    return $type;
+}
+
+/**
  * データベースに接続し、接続オブジェクトを返します。
  * Connects to the database and returns the connection object.
  * @param array $config データベース設定
@@ -98,18 +144,18 @@ function connectDatabase(array $config): ?mysqli
 function createTableIfNotExists(mysqli $conn, array $schema): bool
 {
     try {
-        $tableName = $conn->real_escape_string($schema['tableName']);
+        $tableName = quoteIdentifier($schema['tableName']);
         $columnsSql = [];
         foreach ($schema['columns'] as $colName => $colDetails) {
-            $columnsSql[] = "`{$colName}` {$colDetails['type']}";
+            $columnsSql[] = quoteIdentifier($colName) . ' ' . validateColumnType($colDetails['type']);
         }
         $columnsSqlString = implode(', ', $columnsSql);
 
-        $sql = "CREATE TABLE IF NOT EXISTS `{$tableName}` ({$columnsSqlString}) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+        $sql = "CREATE TABLE IF NOT EXISTS {$tableName} ({$columnsSqlString}) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
         $conn->query($sql);
 
         // テーブルが空の場合、サンプルデータを挿入
-        $result = $conn->query("SELECT COUNT(*) as count FROM `{$tableName}`");
+        $result = $conn->query("SELECT COUNT(*) as count FROM {$tableName}");
         $row = $result->fetch_assoc();
         if ($row['count'] == 0) {
             insertSampleData($conn, $schema);
@@ -128,14 +174,14 @@ function createTableIfNotExists(mysqli $conn, array $schema): bool
  * @param array $schema テーブルスキーマ定義
  */
 function insertSampleData(mysqli $conn, array $schema) {
-    $tableName = $conn->real_escape_string($schema['tableName']);
+    $tableName = quoteIdentifier($schema['tableName']);
 
     // 挿入するカラムのリストを作成 (AUTO_INCREMENTは除く)
     $columnNames = array_keys($schema['columns']);
     $insertColumns = array_filter($columnNames, function($colName) use ($schema) {
         return strpos($schema['columns'][$colName]['type'], 'AUTO_INCREMENT') === false;
     });
-    $columnsSqlString = '`' . implode('`, `', $insertColumns) . '`';
+    $columnsSqlString = implode(', ', array_map('quoteIdentifier', $insertColumns));
 
     // サンプルデータ
     $samples = [
@@ -146,7 +192,7 @@ function insertSampleData(mysqli $conn, array $schema) {
             'phone_number' => '06-1234-5678',
             'description' => '濃厚豚骨スープが自慢のラーメン店です。ホール・キッチンスタッフ募集中！',
             'website' => 'https://example.com/menyado',
-            'posted_date' => 'NOW()'
+            'posted_date' => date('Y-m-d H:i:s')
         ],
         [
             'store_name' => '株式会社クリエイティブデザイン',
@@ -155,7 +201,7 @@ function insertSampleData(mysqli $conn, array $schema) {
             'phone_number' => '06-8765-4321',
             'description' => '最新技術を使ったWebサイトを制作します。Webデザイナー・エンジニアを募集しています。',
             'website' => 'https://example.com/creative',
-            'posted_date' => 'NOW()'
+            'posted_date' => date('Y-m-d H:i:s')
         ],
         [
             'store_name' => '旅する本屋',
@@ -164,13 +210,13 @@ function insertSampleData(mysqli $conn, array $schema) {
             'phone_number' => '06-1122-3344',
             'description' => '世界中の珍しい本を取り揃えています。週末だけのアルバイト募集中。',
             'website' => 'https://example.com/bookstore',
-            'posted_date' => 'NOW()'
+            'posted_date' => date('Y-m-d H:i:s')
         ]
     ];
 
     // プリペアドステートメントの準備
     $placeholders = implode(', ', array_fill(0, count($insertColumns), '?'));
-    $stmt = $conn->prepare("INSERT INTO `{$tableName}` ({$columnsSqlString}) VALUES ({$placeholders})");
+    $stmt = $conn->prepare("INSERT INTO {$tableName} ({$columnsSqlString}) VALUES ({$placeholders})");
 
     // 各データをバインドして実行
     foreach ($samples as $sample) {
@@ -198,8 +244,8 @@ function insertSampleData(mysqli $conn, array $schema) {
 function fetchData(mysqli $conn, string $tableName): array
 {
     try {
-        $tableName = $conn->real_escape_string($tableName);
-        $sql = "SELECT * FROM `{$tableName}` ORDER BY `posted_date` DESC";
+        $tableName = quoteIdentifier($tableName);
+        $sql = "SELECT * FROM {$tableName} ORDER BY `posted_date` DESC";
         $result = $conn->query($sql);
         return $result->fetch_all(MYSQLI_ASSOC);
     } catch (Exception $e) {

--- a/learn/ContactFormController.php
+++ b/learn/ContactFormController.php
@@ -11,7 +11,9 @@ use App\Models\Contact;
 
 class ContactFormController extends Controller
 {
-
+    /**
+     * お問い合わせ一覧画面を表示
+     *
      * @return \Illuminate\Http\Response
      */
     public function index()
@@ -200,26 +202,49 @@ class ContactFormController extends Controller
      */
     public function admin(Request $request)
     {
+        $validated = $request->validate([
+            'status' => 'nullable|in:pending,in_progress,completed',
+            'search' => 'nullable|string|max:100',
+        ]);
+
         $query = Contact::query();
 
         // ステータスでフィルタリング
-        if ($request->has('status') && $request->status !== '') {
-            $query->where('status', $request->status);
+        // 値は上のバリデーションで既知の 3 つに限定済み
+        if (!empty($validated['status'])) {
+            $query->where('status', $validated['status']);
         }
 
         // 検索
-        if ($request->has('search') && $request->search !== '') {
-            $search = $request->search;
-            $query->where(function ($q) use ($search) {
-                $q->where('name', 'like', '%' . $search . '%')
-                  ->orWhere('email', 'like', '%' . $search . '%')
-                  ->orWhere('subject', 'like', '%' . $search . '%');
+        if (!empty($validated['search'])) {
+            $pattern = '%' . $this->escapeLike($validated['search']) . '%';
+            $query->where(function ($q) use ($pattern) {
+                $q->where('name', 'like', $pattern)
+                  ->orWhere('email', 'like', $pattern)
+                  ->orWhere('subject', 'like', $pattern);
             });
         }
 
         $contacts = $query->orderBy('created_at', 'desc')
-                         ->paginate(20);
+                         ->paginate(20)
+                         ->withQueryString();
 
         return view('contacts.admin', compact('contacts'));
+    }
+
+    /**
+     * LIKE のワイルドカードをエスケープする。
+     *
+     * バインドは SQL インジェクションを防ぐが、値の中の % と _ は
+     * ワイルドカードとして解釈されたままになる。
+     * search=% を送ると絞り込みが無効化されて全件が返り、
+     * %a%b%c%d%e%... のような入力はインデックスが効かず全表スキャンになる。
+     *
+     * @param  string  $value
+     * @return string
+     */
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value);
     }
 }

--- a/nww/customercontroller.php
+++ b/nww/customercontroller.php
@@ -1,24 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Customer;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class CustomerController extends Controller
 {
-    public function index()
+    /** 1 ページあたりの件数 */
+    private const PER_PAGE = 20;
+
+    public function index(): View
     {
-        $customers = Customer::all();
+        // Customer::all() は全件をメモリに載せる。件数が増えるとそのまま
+        // メモリ枯渇につながるのでページネーションを使う。
+        $customers = Customer::query()
+            ->orderBy('id')
+            ->paginate(self::PER_PAGE);
+
         return view('dashboard', compact('customers'));
     }
 
-    public function search(Request $request)
+    public function search(Request $request): View
     {
-        $search = $request->input('search'); // 文法エラーの修正（セミコロン追加）
+        $validated = $request->validate([
+            'search' => ['nullable', 'string', 'max:100'],
+        ]);
 
-        $customers = Customer::where('name', 'like', '%' . $search . '%')
-            ->orWhere('email', 'like', '%' . $search . '%')
-            ->get();
+        $search = trim((string) ($validated['search'] ?? ''));
+
+        $customers = Customer::query()
+            ->when($search !== '', function ($query) use ($search): void {
+                $pattern = '%' . $this->escapeLike($search) . '%';
+
+                // orWhere をトップレベルに置くと、他の絞り込み条件
+                // (論理削除やテナント条件など) を OR がまたいで
+                // 打ち消してしまう。検索条件はグループにまとめる。
+                $query->where(function ($query) use ($pattern): void {
+                    $query->where('name', 'like', $pattern)
+                        ->orWhere('email', 'like', $pattern);
+                });
+            })
+            ->orderBy('id')
+            ->paginate(self::PER_PAGE)
+            ->withQueryString();
 
         return view('dashboard', compact('customers'));
+    }
+
+    /**
+     * LIKE のワイルドカードをエスケープする。
+     *
+     * バインドは SQL インジェクションを防ぐが、値の中の % と _ は
+     * ワイルドカードとして解釈されたままになる。
+     * 例えば search=% を送ると全件がヒットし、
+     * %a%b%c%d%e%... のような入力は前方一致が効かず全表スキャンになる
+     * （ReDoS ならぬ LIKE による DoS）。
+     */
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value);
     }
 }

--- a/table.php
+++ b/table.php
@@ -73,7 +73,7 @@ $data = $stmt->fetchAll();
         <?php foreach ($data as $row): ?>
             <tr>
                 <?php foreach ($columns as $key => $_): ?>
-                    <td><?= htmlspecialchars($row[$key]) ?></td>
+                    <td><?= htmlspecialchars((string) ($row[$key] ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></td>
                 <?php endforeach; ?>
             </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
## 1. `database.php` — `real_escape_string()` を識別子に使っていた

```php
$tableName = $conn->real_escape_string($schema['tableName']);
$sql = "SELECT * FROM `{$tableName}` ORDER BY `posted_date` DESC";
```

`real_escape_string()` がエスケープするのは `'` `"` `\` `NUL` など **文字列リテラル用**の文字です。識別子の区切り文字であるバッククォートは対象外なので、バッククォートを含む値を渡すとクォートの外に抜け出せます。

さらに、カラムの型定義はチェックなしで `CREATE TABLE` に埋め込まれていました。

```php
$columnsSql[] = "`{$colName}` {$colDetails['type']}";   // ← type は無検査
```

識別子は**プレースホルダにできない**ため、使ってよい文字を限定するしかありません。`quoteIdentifier()` と `validateColumnType()` を追加し、識別子を組み立てている 4 箇所すべてをこれらを通すよう変更しました。不正な値は `InvalidArgumentException` で弾きます。

併せて、サンプルデータの `'posted_date' => 'NOW()'` を修正しています。`bind_param` に `'s'` として渡していたため、SQL 関数ではなく**リテラル文字列 `"NOW()"`** が INSERT されていました。

## 2. LIKE のワイルドカード未エスケープ

`nww/customercontroller.php` と `learn/ContactFormController.php`：

```php
->where('name', 'like', '%' . $search . '%')
```

バインド自体はされているので SQL インジェクションにはなりませんが、**値の中の `%` と `_` はワイルドカードとして解釈されたまま**です。

- `search=%` を送ると絞り込みが無効化され、全件が返ります（`WHERE name LIKE '%%%'`）
- `%a%b%c%d%e%f%g%...` のような入力はインデックスが効かず全表スキャンになり、DoS に使えます

`escapeLike()` を追加し、`\` `%` `_` をエスケープするようにしました。併せて `search` / `status` に `validate()`（100 文字上限）を追加しています。

### `nww/customercontroller.php` の追加修正

- `Customer::all()` → `paginate()`。全件をメモリに載せていました。
- `orWhere` がトップレベルに置かれていたため、将来ほかの絞り込み条件（論理削除・テナント条件など）を足したときに **OR がそれをまたいで打ち消す**形になっていました。検索条件を `where(function () {...})` でグループ化しています。

## 3. `table.php`

`htmlspecialchars($row[$key])` が `null` を受けると PHP 8.1 以降 Deprecated になるため、`(string)` キャストと `ENT_QUOTES | ENT_SUBSTITUTE` を追加しました。

## 注意

`learn/ContactFormController.php` の docblock 欠落による Parse error は #46 でも直していますが、**このブランチ単体で `php -l` を通すため**同じ修正をこちらにも含めています（同一の変更なのでマージ時に競合しません）。

## 確認

```
$ php -l database.php table.php nww/customercontroller.php learn/ContactFormController.php
No syntax errors detected
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0168HSPWgAAvWaQvfZEkbkdT)_