### PR TITLE
fix(security): セッション固定化・権限チェックの緩い比較・クッキー属性を修正

### DIFF
--- a/SessionManager.php
+++ b/SessionManager.php
@@ -1,3 +1,5 @@
+<?php
+
 // ====================================================================
 // 5. SessionManager クラス（セッション管理の改善）
 // ====================================================================
@@ -21,17 +23,32 @@ class SessionManager
      */
     private function initializeSession(): void
     {
-        // セキュアなセッション設定
-        ini_set('session.gc_maxlifetime', $this->sessionTimeout);
-        ini_set('session.cookie_lifetime', $this->sessionTimeout);
-        ini_set('session.cookie_httponly', 1);
-        ini_set('session.cookie_secure', $this->isHttps());
-        ini_set('session.cookie_samesite', 'Strict');
-        ini_set('session.use_strict_mode', 1);
-        
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
+        // セッション開始後に ini_set しても効果がないので、
+        // すでに開始済みなら何もしない。
+        if (session_status() !== PHP_SESSION_NONE) {
+            return;
         }
+
+        // セキュアなセッション設定
+        ini_set('session.gc_maxlifetime', (string) $this->sessionTimeout);
+
+        // cookie_lifetime は 0 (ブラウザを閉じるまで) にする。
+        // 有効期限を持つ cookie はディスクへ永続化されるため、
+        // 共用端末では次の利用者がファイルを読める。
+        // セッションの寿命は $sessionTimeout によるサーバ側判定で管理する。
+        ini_set('session.cookie_lifetime', '0');
+
+        ini_set('session.cookie_httponly', '1');
+        ini_set('session.cookie_secure', $this->isHttps() ? '1' : '0');
+        ini_set('session.cookie_samesite', 'Strict');
+        ini_set('session.use_strict_mode', '1');
+
+        // セッション ID を URL に載せない。
+        // 有効だと Referer やアクセスログ経由で ID が漏れる。
+        ini_set('session.use_only_cookies', '1');
+        ini_set('session.use_trans_sid', '0');
+
+        session_start();
     }
     
     /**
@@ -69,15 +86,19 @@ class SessionManager
     {
         try {
             $validUserId = InputValidator::validateUserId($userId);
-            
-            $_SESSION['user_id'] = $validUserId;
-            $_SESSION['login_time'] = time();
-            $_SESSION['last_access'] = time();
-            $_SESSION['fingerprint'] = $this->generateFingerprint();
-            
-            // セッション再生成（セキュリティ向上）
+
+            // セッション固定化対策。
+            // ログイン「前」に攻撃者が握らせた ID を無効にする必要があるので、
+            // 権限をセッションへ書き込む前に ID を振り直す。
             session_regenerate_id(true);
-            
+
+            $now = time();
+            $_SESSION['user_id'] = $validUserId;
+            $_SESSION['login_time'] = $now;
+            $_SESSION['last_access'] = $now;
+            $_SESSION['last_regenerated'] = $now;
+            $_SESSION['fingerprint'] = $this->generateFingerprint();
+
             log_message('info', "User {$validUserId} logged in successfully");
             return true;
             
@@ -110,25 +131,41 @@ class SessionManager
         }
         
         // 定期的なセッションID再生成
-        $loginTime = $_SESSION['login_time'] ?? time();
-        if (time() - $loginTime > $this->regenerateInterval) {
+        //
+        // 修正前は再生成のたびに login_time を上書きしていたため、
+        //   - ログイン時刻が分からなくなる（監査・絶対有効期限の判定に使えない）
+        //   - 5 分ごとに login_time が更新され続けるので、
+        //     絶対有効期限を足したくても実装できない
+        // という問題があった。再生成の時刻は別のキーで管理する。
+        $lastRegenerated = $_SESSION['last_regenerated'] ?? 0;
+        if (time() - $lastRegenerated > $this->regenerateInterval) {
             session_regenerate_id(true);
-            $_SESSION['login_time'] = time();
+            $_SESSION['last_regenerated'] = time();
         }
-        
+
         return true;
     }
-    
+
     /**
      * セッションフィンガープリントの生成
+     *
+     * リクエストごとに変わりうる値を混ぜるとセッションが無用に切れるため、
+     * 比較的安定した値だけを使う。
+     *
+     * 除外した理由:
+     *   REMOTE_ADDR         モバイル回線や企業プロキシでは IP が頻繁に変わる。
+     *                       同一 NAT 配下からの攻撃も防げないため費用対効果が悪い。
+     *   HTTP_ACCEPT_ENCODING  プロキシや CDN が書き換えることがある。
+     *
+     * なお、これらの値はクライアントが自由に送れるヘッダなので、
+     * フィンガープリントはあくまで多層防御の一枚であり、
+     * これ単体でセッションハイジャックを防げるものではない。
      */
     private function generateFingerprint(): string
     {
-        return hash('sha256', 
-            ($_SERVER['HTTP_USER_AGENT'] ?? '') .
-            ($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '') .
-            ($_SERVER['REMOTE_ADDR'] ?? '') .
-            ($_SERVER['HTTP_ACCEPT_ENCODING'] ?? '')
+        return hash('sha256',
+            ($_SERVER['HTTP_USER_AGENT'] ?? '') . '|' .
+            ($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '')
         );
     }
     
@@ -154,31 +191,54 @@ class SessionManager
     public function destroySession(): void
     {
         if (session_status() === PHP_SESSION_ACTIVE) {
+            $sessionName = session_name();
+            // 設定値は session_destroy() の前に読んでおく。
+            $params = session_get_cookie_params();
+            $useCookies = (bool) ini_get('session.use_cookies');
+
             // セッションデータクリア
             session_unset();
             session_destroy();
-            
+
             // クッキー削除
-            if (ini_get("session.use_cookies")) {
-                $params = session_get_cookie_params();
-                setcookie(session_name(), '', time() - 42000,
-                    $params["path"], $params["domain"],
-                    $params["secure"], $params["httponly"]
-                );
+            // 元のコードは SameSite 属性を指定していなかった。
+            // 削除用の Set-Cookie は発行時と属性が一致しないと
+            // ブラウザに無視され、クッキーが残ることがある。
+            if ($useCookies) {
+                setcookie($sessionName, '', [
+                    'expires'  => time() - 42000,
+                    'path'     => $params['path'],
+                    'domain'   => $params['domain'],
+                    'secure'   => $params['secure'],
+                    'httponly' => $params['httponly'],
+                    'samesite' => $params['samesite'] ?: 'Strict',
+                ]);
             }
-            
+
             log_message('info', 'Session destroyed successfully');
         }
     }
-    
+
     /**
      * HTTPS接続の確認
      */
     private function isHttps(): bool
     {
-        return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ||
-               $_SERVER['SERVER_PORT'] == 443 ||
-               (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
+        if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
+            return true;
+        }
+
+        // CLI では SERVER_PORT が存在しないため、元のコードは
+        // Warning: Undefined array key "SERVER_PORT" を出していた。
+        if (($_SERVER['SERVER_PORT'] ?? null) == 443) {
+            return true;
+        }
+
+        // X-Forwarded-Proto はクライアントが自由に送れるヘッダなので、
+        // 信頼できるリバースプロキシ配下でのみ参照すること。
+        // プロキシがこのヘッダを必ず上書きする設定になっているかを確認する。
+        return isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+            && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https';
     }
     
     /**
@@ -207,7 +267,13 @@ class SessionManager
         }
         
         $userPermissions = $_SESSION['permissions'] ?? [];
-        return in_array($permission, $userPermissions) || in_array('admin', $userPermissions);
+
+        // in_array の第 3 引数を省略すると緩い比較になる。
+        // 権限リストに数値が紛れ込んでいる場合、
+        // in_array('admin', [0]) が true になり全権限が通ってしまう。
+        // 厳密比較を必ず指定する。
+        return in_array($permission, $userPermissions, true)
+            || in_array('admin', $userPermissions, true);
     }
     
     /**
@@ -221,7 +287,8 @@ class SessionManager
     /**
      * Flash メッセージの取得
      */
-    public function getFlashMessages(string $type = null): array
+    // PHP 8.4 以降、null デフォルト値による暗黙の nullable は Deprecated。
+    public function getFlashMessages(?string $type = null): array
     {
         if ($type) {
             $messages = $_SESSION['flash_messages'][$type] ?? [];

--- a/learn/sessiontest_2.php
+++ b/learn/sessiontest_2.php
@@ -1,35 +1,65 @@
 <?php
 
+declare(strict_types=1);
+
+// セッション破棄のサンプル。
+// ログアウト処理はここと同じ 3 手順を必ずセットで行う。
+
+// クッキー削除の Set-Cookie ヘッダを送る必要があるため、
+// HTML を出力する前に処理を済ませる。
 session_start();
+
+// 1. サーバ側のセッション変数を空にする
+$_SESSION = [];
+
+// 2. セッションクッキーを削除する
+//
+//    修正前の問題:
+//      - クッキー名を 'PHPSESSID' と直書きしていた。session.name は
+//        php.ini で変更できるため、名前が違うと削除されない。
+//        session_name() で実際の名前を取る。
+//      - path しか指定していなかった。削除用の Set-Cookie は
+//        発行時と属性 (domain / secure / httponly / samesite) が
+//        一致しないとブラウザに無視され、クッキーが残る。
+//        session_get_cookie_params() から実際の設定を引く。
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', [
+        'expires'  => time() - 1800,
+        'path'     => $params['path'],
+        'domain'   => $params['domain'],
+        'secure'   => $params['secure'],
+        'httponly' => $params['httponly'],
+        'samesite' => $params['samesite'] ?: 'Lax',
+    ]);
+}
+
+// 3. サーバ側のセッションファイルを破棄する
+session_destroy();
 
 ?>
 
 <html>
-    <head></head>
+    <head><meta charset="UTF-8"></head>
     <body>
 
     <?php
 
     echo 'セッション破棄しました';
 
-    $_SESSION = [];
+    echo 'セッション';
+    echo '<pre>';
+    var_dump($_SESSION);
+    echo '</pre>';
 
-    if(isset($_COOKIE['PHPSESSID'])){
-    setcookie('PHPSESSID', '', time() - 1800, '/');
-}
+    // 注意: $_COOKIE は「このリクエストで受け取った値」なので、
+    // setcookie() を呼んでもこの場では変わらない。
+    // 削除されたことは次のリクエストで確認する。
+    echo 'クッキー';
+    echo '<pre>';
+    var_dump($_COOKIE);
+    echo '</pre>';
 
-session_destroy();
-
-echo 'セッション';
-echo '<pre>';
-var_dump($_SESSION);
-echo '</pre>';
-
-echo 'クッキー';
-echo '<pre>';
-var_dump($_COOKIE);
-echo '</pre>';
-
-?>
+    ?>
 
     </body></html>


### PR DESCRIPTION
## `SessionManager.php`

### 1. セッション固定化（session fixation）

```php
$_SESSION['user_id'] = $validUserId;
$_SESSION['login_time'] = time();
...
session_regenerate_id(true);   // ← 権限を書き込んだ「後」
```

`session_regenerate_id()` の目的は、**ログイン前に攻撃者が握らせた ID を無効化する**ことです。権限をセッションへ書き込んだ後に振り直すと、書き込みと再生成の間で処理が中断した場合に、攻撃者の知る ID に認証済みの状態が残ります。順序を入れ替えました。

### 2. `login_time` の二重利用

```php
$loginTime = $_SESSION['login_time'] ?? time();
if (time() - $loginTime > $this->regenerateInterval) {
    session_regenerate_id(true);
    $_SESSION['login_time'] = time();   // ← ログイン時刻を上書き
}
```

5 分ごとの ID 再生成のたびに**ログイン時刻が上書き**されます。本来のログイン時刻が失われるため、絶対有効期限（「ログインから 8 時間で強制ログアウト」など）を実装できず、監査ログにも使えません。再生成時刻は `last_regenerated` として別に持つよう変更しました。

### 3. 権限チェックの緩い比較

```php
return in_array($permission, $userPermissions) || in_array('admin', $userPermissions);
```

`in_array()` の第 3 引数を省略すると**緩い比較**になります。権限リストに数値が紛れ込んでいると `in_array('admin', [0])` が `true` を返し、**全権限が通ります**。厳密比較を指定しました。

### 4. フィンガープリント

`REMOTE_ADDR` と `HTTP_ACCEPT_ENCODING` を含めていましたが、

- モバイル回線や企業プロキシでは IP が頻繁に変わり、**正規ユーザーのセッションが切れます**
- 同一 NAT 配下からの攻撃は防げないため、切れるコストに見合いません
- `ACCEPT_ENCODING` はプロキシや CDN が書き換えることがあります

比較的安定した `User-Agent` と `Accept-Language` のみに変更し、これが多層防御の一枚に過ぎない旨をコメントで明記しました。

### 5. セッションクッキーの設定

- `cookie_lifetime` を `3600` → `0` に変更。**有効期限付きクッキーはディスクへ永続化される**ため、共用端末で次の利用者がファイルを読めます。寿命はサーバ側の `$sessionTimeout` 判定で管理します。
- `use_only_cookies` / `use_trans_sid` を明示。セッション ID が URL に載ると Referer やアクセスログから漏れます。
- `destroySession()` のクッキー削除に `samesite` を追加。削除用の `Set-Cookie` は**発行時と属性が一致しないとブラウザに無視され**、クッキーが残ります。
- `ini_set` はセッション開始後には効かないため、開始済みなら早期 return するようにしました。

### 6. その他

- `isHttps()` が `$_SERVER['SERVER_PORT']` を直接参照しており、CLI で `Warning: Undefined array key "SERVER_PORT"` になっていました。
- `getFlashMessages(string $type = null)` は PHP 8.4 で Deprecated（暗黙の nullable）。`?string` に修正。

## `learn/sessiontest_2.php`

```php
if (isset($_COOKIE['PHPSESSID'])) {
    setcookie('PHPSESSID', '', time() - 1800, '/');
}
```

- クッキー名を `'PHPSESSID'` と**直書き**していました。`session.name` は php.ini で変更できるため、名前が違うと削除されません。`session_name()` を使います。
- `path` しか指定しておらず、`domain` / `secure` / `httponly` / `samesite` が発行時と一致しないため、ブラウザに無視されえます。`session_get_cookie_params()` から実際の設定を引くようにしました。
- `setcookie()` を **HTML 出力後**に呼んでいたため `headers already sent` になります。`session_start()` の直後へ移動しました。

## 注意

`SessionManager.php` への `<?php` 追加は #49 と同一の修正です。このブランチ単体で `php -l` を通すために含めています。

---
_Generated by [Claude Code](https://claude.ai/code/session_0168HSPWgAAvWaQvfZEkbkdT)_