### PR TITLE
fix(security): CSRF トークン検証のバイパスを修正

### DIFF
--- a/learn_2/input.php
+++ b/learn_2/input.php
@@ -21,6 +21,40 @@ function h($str)
     return htmlspecialchars($str, ENT_QUOTES, 'UTF-8');
 }
 
+/**
+ * CSRF トークンを検証する。
+ *
+ * 修正前は次のように書かれていた。
+ *
+ *     if ($_POST['csrf'] === $_SESSION['csrfToken'])
+ *
+ * この比較には 2 つの問題がある。
+ *
+ * 1. トークン検証を素通りできる
+ *    どちらのキーも未定義だと、PHP 8 では Warning が出たうえで
+ *    両辺とも null になり、null === null が true になる。
+ *    つまりセッションにトークンが無い状態で、csrf を一切含まない
+ *    POST を送ると検証を通過してしまう。
+ *
+ * 2. タイミング攻撃に対して安全でない
+ *    === は最初に異なるバイトが見つかった時点で false を返すため、
+ *    比較にかかる時間からトークンを 1 バイトずつ推測できる。
+ *    hash_equals() は長さに比例した一定時間で比較する。
+ */
+function verifyCsrfToken(): bool
+{
+    $sessionToken = $_SESSION['csrfToken'] ?? '';
+    $postedToken  = $_POST['csrf'] ?? '';
+
+    // 空同士が一致してしまわないよう、実在することを先に確認する。
+    if (!is_string($sessionToken) || $sessionToken === ''
+        || !is_string($postedToken) || $postedToken === '') {
+        return false;
+    }
+
+    return hash_equals($sessionToken, $postedToken);
+}
+
 // 入力、確認、完了　input.php, confirm.php, thanks.php
 // CSRF 偽物のinput.php→悪意のあるページ
 // input.php
@@ -52,7 +86,7 @@ if (!empty($_POST['btn_submit'])) {
 <body>
 
     <?php if ($pageFlag === 1) : ?>
-        <?php if ($_POST['csrf'] === $_SESSION['csrfToken']) : ?>
+        <?php if (verifyCsrfToken()) : ?>
             <?php
             // セキュリティ: セッション固定攻撃対策としてセッションIDを再生成
             session_regenerate_id(true);
@@ -134,7 +168,7 @@ if (!empty($_POST['btn_submit'])) {
         <?php endif; ?>
     <?php endif; ?>
 
-    <?php if ($pageFlag === 1 && isset($_POST['csrf']) && $_POST['csrf'] === $_SESSION['csrfToken']) : ?>
+    <?php if ($pageFlag === 1 && verifyCsrfToken()) : ?>
         <form method="POST" action="input2.php">
             <?php if (!empty($_SESSION)) : ?>
                 <pre>
@@ -147,7 +181,7 @@ if (!empty($_POST['btn_submit'])) {
 
 
     <?php if ($pageFlag === 2) : ?>
-        <?php if ($_POST['csrf'] === $_SESSION['csrfToken']) : ?>
+        <?php if (verifyCsrfToken()) : ?>
             <?php
             // セキュリティ: セッション固定攻撃対策としてセッションIDを再生成
             session_regenerate_id(true);

--- a/learn_2/input2.php
+++ b/learn_2/input2.php
@@ -29,6 +29,40 @@ function h($str)
     return htmlspecialchars($str, ENT_QUOTES, 'UTF-8');
 }
 
+/**
+ * CSRF トークンを検証する。
+ *
+ * 修正前は次のように書かれていた。
+ *
+ *     if ($_POST['csrf'] === $_SESSION['csrfToken'])
+ *
+ * この比較には 2 つの問題がある。
+ *
+ * 1. トークン検証を素通りできる
+ *    どちらのキーも未定義だと、PHP 8 では Warning が出たうえで
+ *    両辺とも null になり、null === null が true になる。
+ *    つまりセッションにトークンが無い状態で、csrf を一切含まない
+ *    POST を送ると検証を通過してしまう。
+ *
+ * 2. タイミング攻撃に対して安全でない
+ *    === は最初に異なるバイトが見つかった時点で false を返すため、
+ *    比較にかかる時間からトークンを 1 バイトずつ推測できる。
+ *    hash_equals() は長さに比例した一定時間で比較する。
+ */
+function verifyCsrfToken(): bool
+{
+    $sessionToken = $_SESSION['csrfToken'] ?? '';
+    $postedToken  = $_POST['csrf'] ?? '';
+
+    // 空同士が一致してしまわないよう、実在することを先に確認する。
+    if (!is_string($sessionToken) || $sessionToken === ''
+        || !is_string($postedToken) || $postedToken === '') {
+        return false;
+    }
+
+    return hash_equals($sessionToken, $postedToken);
+}
+
 // 入力、確認、完了　input.php, confirm.php, thanks.php
 // CSRF 偽物のinput.php→悪意のあるページ
 // input.php
@@ -74,7 +108,7 @@ if (!empty($_POST['btn_submit'])) {
 
 <body>
     <?php if ($pageFlag === 1): ?>
-    <?php if ($_POST['csrf'] === $_SESSION['csrfToken']): ?>
+    <?php if (verifyCsrfToken()): ?>
     <form method="POST" action="input2.php">
         <div class="container">
             <div class="row">
@@ -136,7 +170,7 @@ if (!empty($_POST['btn_submit'])) {
     <?php endif; ?>
 
     <?php if ($pageFlag === 2): ?>
-        <?php if ($_POST['csrf'] === $_SESSION['csrfToken']): ?>
+        <?php if (verifyCsrfToken()): ?>
             送信が完了しました。
             <?php unset($_SESSION['csrfToken']); ?>
         <?php endif; ?>


### PR DESCRIPTION
`learn_2/input.php` と `learn_2/input2.php` は、CSRF トークンを次のように検証していました。

```php
if ($_POST['csrf'] === $_SESSION['csrfToken'])
```

## 1. 検証を素通りできる

どちらのキーも未定義だと**両辺とも `null` になり、`null === null` が `true`** になります。

```
$ php -r '$_POST = []; $_SESSION = []; var_dump(@($_POST["csrf"] === $_SESSION["csrfToken"]));'
bool(true)
```

つまり、セッションに `csrfToken` が無い状態で **`csrf` フィールドを一切含まない POST** を送れば検証を通過します。

そして「セッションに `csrfToken` が無い」状況は普通に発生します。

- トークンを生成しているのは `$pageFlag === 0` の分岐だけなので、**フォーム画面を一度も開いていない訪問者**のセッションには存在しません
- 送信完了時に `unset($_SESSION['csrfToken'])` しているので、**一度送信した後**のセッションにも存在しません

攻撃者は罠ページから `csrf` 無しの POST を直接投げるだけでよく、トークンを盗む必要すらありません。CSRF 対策が実質無効な状態でした。

## 2. タイミング攻撃に対して安全でない

`===` は最初に異なるバイトを見つけた時点で `false` を返すため、比較にかかる時間の差からトークンを 1 バイトずつ推測できます。

## 対応

`verifyCsrfToken()` を追加し、5 箇所すべての比較をこれに置き換えました。

```php
function verifyCsrfToken(): bool
{
    $sessionToken = $_SESSION['csrfToken'] ?? '';
    $postedToken  = $_POST['csrf'] ?? '';

    // 空同士が一致してしまわないよう、実在することを先に確認する
    if (!is_string($sessionToken) || $sessionToken === ''
        || !is_string($postedToken) || $postedToken === '') {
        return false;
    }

    return hash_equals($sessionToken, $postedToken);
}
```

- 両辺が**空でない文字列**であることを先に確認（`null` 同士・空文字同士の一致を防ぐ）
- 比較は `hash_equals()` で、長さに比例した一定時間で実行

## 確認

```
$ php -l learn_2/input.php learn_2/input2.php
No syntax errors detected
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0168HSPWgAAvWaQvfZEkbkdT)_