### PR TITLE
ci: PHP の構文チェックと `&lt;?php` 開始タグ検査を CI に追加

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,114 @@
+name: PHP Lint
+
+# このリポジトリには「1 ファイルに複数ファイル分のコードが連結されている」
+# 「<?php 開始タグが無い」といった、読み込んだ瞬間に落ちるファイルが
+# 繰り返し混入していた。php -l を CI で回して再発を防ぐ。
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: php -l (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 現行の安定版と、1 つ前のバージョン。
+        # 8.4 では暗黙の nullable 引数などが Deprecated になるため、
+        # 両方で確認しておく。
+        php-version: ['8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: none
+
+      - name: Lint all PHP files
+        run: |
+          set -uo pipefail
+
+          status=0
+          count=0
+
+          # Blade テンプレートは PHP の構文ではないディレクティブ
+          # (@extends, @section など) を含むため対象外にする。
+          while IFS= read -r -d '' file; do
+            count=$((count + 1))
+            if ! output=$(php -l "$file" 2>&1); then
+              echo "::error file=${file}::${output}"
+              status=1
+            fi
+          done < <(
+            find . \
+              -path ./.git -prune -o \
+              -path ./vendor -prune -o \
+              -path ./node_modules -prune -o \
+              -type f -name '*.php' ! -name '*.blade.php' -print0
+          )
+
+          echo "Checked ${count} PHP files."
+
+          if [ "$status" -ne 0 ]; then
+            echo "::error::PHP syntax errors found."
+          else
+            echo "All PHP files passed php -l."
+          fi
+
+          exit "$status"
+
+      - name: Check for missing <?php opening tags
+        run: |
+          set -uo pipefail
+
+          # 開始タグの無い .php ファイルは、Web サーバ経由でアクセスすると
+          # ソースコードがそのままレスポンスとして返る。
+          #
+          # HTML / Blade だけを含むテンプレートは開始タグが無くて正しいので、
+          # 「PHP のコードらしき記述があるのに開始タグが無い」ものだけを拾う。
+          status=0
+
+          while IFS= read -r -d '' file; do
+            if grep -q '<?php\|<?=' "$file"; then
+              continue
+            fi
+
+            # 最初の非空行が '<' か '@' で始まるものは HTML / Blade
+            # テンプレート。開始タグが無くて正しいので対象外。
+            # (JavaScript の function / class を PHP と誤検出しないため)
+            first_char=$(grep -m1 -v '^[[:space:]]*$' "$file" | cut -c1)
+            if [ "$first_char" = '<' ] || [ "$first_char" = '@' ]; then
+              continue
+            fi
+
+            # namespace / use / class / function など、
+            # PHP のコードでしか出てこない行があるか
+            if grep -qE '^\s*(namespace|use|declare|abstract|final|class|interface|trait|enum|function|public|private|protected)\s' "$file"; then
+              echo "::error file=${file}::Missing <?php opening tag; source would be served as plain text."
+              status=1
+            fi
+          done < <(
+            find . \
+              -path ./.git -prune -o \
+              -path ./vendor -prune -o \
+              -path ./node_modules -prune -o \
+              -type f -name '*.php' ! -name '*.blade.php' -print0
+          )
+
+          if [ "$status" -eq 0 ]; then
+            echo "No PHP files are missing their opening tag."
+          fi
+
+          exit "$status"


### PR DESCRIPTION
## 背景

このリポジトリには、同じ種類の問題が繰り返し混入していました。

- 1 ファイルに複数ファイル分のコードが連結され、2 つ目の `<?php` で Parse error になる（`free.php` / `free2.php` / `free3.php` / `sey.php` / `learn_1/common.php`）
- `<?php` 開始タグが無く、Web 経由でアクセスするとソースがそのまま返る（15 ファイル）

**いずれも `php -l` を一度走らせれば気付けるもの**です。CI で自動化して再発を防ぎます。

## ジョブ 1: `php -l`

PHP 8.3 と 8.4 の両方で全 `.php` ファイルを構文チェックします。8.4 では暗黙の nullable 引数などが Deprecated になるため、両方で見ています。

エラーは `::error file=...` 形式で出力するので、GitHub の diff 上に直接注釈が付きます。

Blade テンプレートは PHP の構文ではないディレクティブ（`@extends`、`@section`）を含むため対象外です。

## ジョブ 2: 開始タグの検査

PHP のコードが書かれているのに `<?php` が無いファイルを検出します。

HTML / Blade だけのテンプレートは開始タグが無くて正しいので、**最初の非空行が `<` か `@` で始まるものは対象外**にしています。これを入れないと、`Game/pachi.php` のような HTML ファイル内の JavaScript の `function` / `class` を PHP と誤検出します。

## 現状

**main ブランチに対しては、まだ両ジョブとも失敗します。**

| チェック | 失敗ファイル数 |
| --- | --- |
| `php -l` | 7 |
| 開始タグ検査 | 15 |

これらは #46 / #47 / #48 / #49 / #50 で修正済みなので、**それらがマージされれば緑になります**。このワークフローは最後にマージするのが良いと思います。

## 既知の限界

開始タグ検査はヒューリスティックなので、`Mailble/web.php` のように `Route::post(...)` から始まるファイル（行頭が PHP キーワードでない）は拾えません。完全な検出ではなく、典型的なパターンを機械的に止めるためのものです。

## 確認

ワークフロー内のシェルスクリプトをローカルで実行し、上記の件数どおりに検出すること、および HTML テンプレートを誤検出しないことを確認済みです。

---
_Generated by [Claude Code](https://claude.ai/code/session_0168HSPWgAAvWaQvfZEkbkdT)_