### PR TITLE
fix(security): learn_8 の認証ミドルウェア外れと RoleMiddleware の null 参照を修正

### DIFF
--- a/learn_8/AuthServiceProvider.php
+++ b/learn_8/AuthServiceProvider.php
@@ -22,11 +22,12 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Gate::define('test', function (User $user) {
-            if($user->id === 1) {
-            return true;
-            }
-            return false;
+        // 注意: これは Gate の書き方を確認するためのサンプル。
+        // 「ID が 1 のユーザーだけ許可」というのは実運用では使えない。
+        // 権限は users.role や専用の権限テーブルで表現し、
+        // 主キーの値に意味を持たせないこと。
+        Gate::define('test', function (User $user): bool {
+            return $user->id === 1;
         });
     }
 }

--- a/learn_8/RoleMiddleware.php
+++ b/learn_8/RoleMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
 use Closure;
@@ -15,9 +17,40 @@ class RoleMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if(auth()->user()->role == 'admin') {
+        $user = $request->user();
+
+        // 未ログインの場合の扱い。
+        //
+        // 修正前は auth()->user()->role を直接参照していたため、
+        // 未ログインでこのミドルウェアを通ると
+        //   Call to a member function ... on null
+        // で 500 になっていた。
+        //
+        // 500 は「サーバ側の不具合」を意味するステータスなので、
+        // 認可の失敗をこれで返すと監視のノイズになるうえ、
+        // 攻撃者に内部エラーの発生を伝えることにもなる。
+        // ログインページへ誘導する。
+        if ($user === null) {
+            return redirect()->route('login');
+        }
+
+        // 役割の比較。
+        //
+        // 修正前は == による緩い比較だった。
+        // role が数値やそれに準ずる値だった場合、
+        // PHP 8 未満では 0 == 'admin' が true になる。
+        // PHP 8 で挙動は変わったが、意図を明示するため === を使う。
+        if ($user->role === 'admin') {
             return $next($request);
-            }
-        return redirect()->route('dashboard');
+        }
+
+        // 権限不足。
+        //
+        // 修正前は dashboard へリダイレクトしていた。
+        // これはユーザーには親切だが、
+        //   - 拒否がアクセスログ上 302 として残るため検知しづらい
+        //   - API クライアントからは成功と区別しにくい
+        // ので 403 を返す。
+        abort(Response::HTTP_FORBIDDEN);
     }
 }

--- a/learn_8/web.php
+++ b/learn_8/web.php
@@ -29,11 +29,21 @@ Route::middleware('auth')->group(function () {
 });
 
 // CHAPTER8でミドルウェア追加
-// Route::middleware(['auth','admin'])->group(function () {
+//
+// 修正前はこのグループの middleware(['auth','admin']) 行だけが
+// コメントアウトされ、中のルートは有効なままだった。
+// その結果 /post と /post/create が未ログインでも誰でも開ける状態で、
+// 管理者向けの投稿一覧が公開されていた。
+//
+// POST /post も同じグループの外にあり、認証ミドルウェアが付いていない。
+// PostController::store() の Gate::authorize('test') が
+// 未ログインを弾いてはいるが、認可 (Gate) だけに頼ると
+// 誰かが Gate の定義を緩めた瞬間に無認証で書き込めるようになる。
+// 認証はミドルウェアで、認可は Gate で、と二段構えにする。
+Route::middleware(['auth', 'admin'])->group(function () {
     Route::get('post', [PostController::class, 'index']);
     Route::get('post/create', [PostController::class, 'create']);
-// });
-
-Route::post('post', [PostController::class, 'store'])->name('post.store');
+    Route::post('post', [PostController::class, 'store'])->name('post.store');
+});
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 1. `learn_8/web.php` — 認証ミドルウェアが外れたままだった

```php
// CHAPTER8でミドルウェア追加
// Route::middleware(['auth','admin'])->group(function () {
    Route::get('post', [PostController::class, 'index']);
    Route::get('post/create', [PostController::class, 'create']);
// });

Route::post('post', [PostController::class, 'store'])->name('post.store');
```

**グループを開く行と閉じる行だけがコメントアウトされ、中のルートは有効なまま残っています。** その結果 `GET /post` と `GET /post/create` は**未ログインでも誰でも開ける**状態で、管理者向けの投稿一覧が公開されていました。

`POST /post` も同じグループの外にあり、認証ミドルウェアが付いていません。`PostController::store()` の `Gate::authorize('test')` が未ログインを弾いてはいますが、**認可（Gate）だけに頼ると、誰かが Gate の定義を緩めた瞬間に無認証で書き込めるようになります**。認証はミドルウェア、認可は Gate、の二段構えにすべきです。

3 つのルートをグループ内へ移しました。

## 2. `learn_8/RoleMiddleware.php` — 未ログインで 500

```php
if(auth()->user()->role == 'admin') {
```

未ログインでこのミドルウェアを通ると `auth()->user()` が `null` になり、

```
Call to a member function ... on null
```

で 500 になります。500 は「サーバ側の不具合」を示すステータスなので、認可の失敗をこれで返すと監視のノイズになりますし、攻撃者に内部エラーの発生を伝えることにもなります。

- `$request->user()` が `null` ならログインページへリダイレクト
- 比較を `==` から `===` へ（意図を明示。PHP 8 で `0 == 'admin'` の挙動は変わりましたが、緩い比較を残す理由がありません）
- 権限不足時は dashboard へのリダイレクトではなく **403** を返す。リダイレクトだと拒否がアクセスログ上 302 として残って検知しづらく、API クライアントからも成功と区別しにくいためです

## 3. `learn_8/AuthServiceProvider.php`

```php
Gate::define('test', function (User $user) {
    if($user->id === 1) {
    return true;
    }
    return false;
});
```

「ID が 1 のユーザーだけ許可」というのは、**主キーの値に権限の意味を持たせている**ため実運用では通用しません。サンプルとしては動くので残しつつ、その旨をコメントで明記しました。併せて `if`/`return` を 1 行にまとめ、戻り値の型を明示しています。

## 確認

```
$ php -l learn_8/RoleMiddleware.php learn_8/web.php learn_8/AuthServiceProvider.php
No syntax errors detected
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0168HSPWgAAvWaQvfZEkbkdT)_