### PR TITLE
fix(security): 例外メッセージの情報漏えいとメール送信の入力未検証を修正

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -69,9 +69,15 @@ class DatabaseOperationService
                     'data' => $data,
                     'where' => $where
                 ]);
+                // 例外メッセージに PDO のエラー文を連結しない。
+                // PDOException のメッセージにはクエリ本文やテーブル名が
+                // 含まれることがあり、この例外がそのまま画面や API の
+                // レスポンスへ出ると内部構造が漏れる。
+                // 詳細は直前の Log::error に残っており、
+                // 元の例外も $previous として保持しているので追跡できる。
                 throw new DatabaseOperationException(
-                    "データベース操作でエラーが発生しました: " . $e->getMessage(), 
-                    0, 
+                    "データベース操作でエラーが発生しました",
+                    0,
                     $e
                 );
             }
@@ -214,9 +220,10 @@ class DatabaseOperationService
                     continue;
                 }
                 
+                // 同上。PDO のエラー文は連結せず、$previous 経由で追跡する。
                 throw new DatabaseOperationException(
-                    "バッチ更新でエラーが発生しました: " . $e->getMessage(), 
-                    0, 
+                    "バッチ更新でエラーが発生しました",
+                    0,
                     $e
                 );
             }

--- a/Mailble/MailController.php
+++ b/Mailble/MailController.php
@@ -1,33 +1,71 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Mail\NotificationMail;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
+use Throwable;
 
 class MailController extends Controller
 {
-    public function send(Request $request)
+    public function send(Request $request): JsonResponse
     {
+        // 入力の検証。
+        //
+        // 修正前は $request->title などを検証せずそのまま使っていた。
+        // recipient_email に至っては、任意のアドレスへメールを送れるため
+        // このエンドポイントがオープンリレーとして悪用できる状態だった。
+        // 少なくとも形式の検証と長さの上限は必須。
+        //
+        // 宛先を利用者が自由に指定できてよいかは要件次第だが、
+        // 通常は「ログイン中のユーザー宛」「管理者宛」のように
+        // サーバ側で決めるべき値。
+        $validated = $request->validate([
+            'recipient_email' => ['required', 'email:rfc', 'max:255'],
+            'title'           => ['required', 'string', 'max:255'],
+            'body'            => ['required', 'string', 'max:5000'],
+            'name'            => ['required', 'string', 'max:100'],
+        ]);
+
         try {
             $mailData = [
-                'title' => $request->title,
-                'body' => $request->body,
-                'name' => $request->name
+                'title' => $validated['title'],
+                'body'  => $validated['body'],
+                'name'  => $validated['name'],
             ];
 
-            Mail::to($request->recipient_email)
+            Mail::to($validated['recipient_email'])
                 ->send(new NotificationMail($mailData));
 
             return response()->json([
                 'message' => 'メールを送信しました。'
             ], 200);
 
-        } catch (\Exception $e) {
+        } catch (Throwable $e) {
+            // 例外メッセージをレスポンスに含めない。
+            //
+            // 修正前は 'error' => $e->getMessage() を返していた。
+            // SMTP の例外メッセージにはホスト名・ポート・認証方式・
+            // 認証失敗の理由などが含まれるため、
+            // 攻撃者にメール基盤の構成を教えることになる。
+            //
+            // 詳細はログに残し、レスポンスには追跡用の ID だけ返す。
+            $errorId = bin2hex(random_bytes(8));
+
+            Log::error('メール送信に失敗しました', [
+                'error_id' => $errorId,
+                'error'    => $e->getMessage(),
+                'trace'    => $e->getTraceAsString(),
+            ]);
+
             return response()->json([
-                'message' => 'メール送信に失敗しました。',
-                'error' => $e->getMessage()
+                'message'  => 'メール送信に失敗しました。',
+                'error_id' => $errorId,
             ], 500);
         }
     }

--- a/database.php
+++ b/database.php
@@ -82,8 +82,14 @@ function connectDatabase(array $config): ?mysqli
         $conn->set_charset('utf8mb4');
         return $conn;
     } catch (Exception $e) {
-        // エラーメッセージをHTMLに表示するためにグローバル変数に格納
-        $GLOBALS['errorMessage'] = $e->getMessage();
+        // 例外メッセージを画面に出さない。
+        //
+        // mysqli の接続例外には、ホスト名・ユーザー名・
+        // 「そのユーザーは存在しない / パスワードが違う」といった
+        // 認証の失敗理由まで含まれる。
+        // 詳細はログへ送り、画面には汎用メッセージだけを出す。
+        error_log('DB connection failed: ' . $e->getMessage());
+        $GLOBALS['errorMessage'] = 'データベースに接続できませんでした。設定を確認してください。';
         return null;
     }
 }
@@ -116,7 +122,10 @@ function createTableIfNotExists(mysqli $conn, array $schema): bool
         }
         return true;
     } catch (Exception $e) {
-        $GLOBALS['errorMessage'] = "Table operation failed: " . $e->getMessage();
+        // SQL の例外メッセージにはクエリ本文やテーブル定義が含まれるため、
+        // ログにのみ残す。
+        error_log('Table operation failed: ' . $e->getMessage());
+        $GLOBALS['errorMessage'] = 'テーブルの準備に失敗しました。';
         return false;
     }
 }
@@ -203,7 +212,8 @@ function fetchData(mysqli $conn, string $tableName): array
         $result = $conn->query($sql);
         return $result->fetch_all(MYSQLI_ASSOC);
     } catch (Exception $e) {
-        $GLOBALS['errorMessage'] = "Error fetching data: " . $e->getMessage();
+        error_log('Error fetching data: ' . $e->getMessage());
+        $GLOBALS['errorMessage'] = 'データの取得に失敗しました。';
         return [];
     }
 }


### PR DESCRIPTION
例外メッセージをそのままユーザーへ返している箇所を修正しました。例外メッセージには接続先ホスト・ユーザー名・認証失敗の理由・クエリ本文といった内部情報が含まれます。

## 1. `database.php` — DB の認証情報が画面に出る

```php
$GLOBALS['errorMessage'] = $e->getMessage();
```

この値は HTML の `.error-message` ブロックに表示されます。mysqli の接続例外メッセージは次のような内容です。

```
Access denied for user 'appuser'@'10.0.1.5' (using password: YES)
```

つまり **DB ユーザー名・アプリサーバの IP・「パスワードは送っているが拒否された」という事実**まで画面に出ます。

3 箇所とも `error_log()` へ送り、画面には汎用メッセージのみ返すよう変更しました。

## 2. `Mailble/MailController.php`

```php
return response()->json([
    'message' => 'メール送信に失敗しました。',
    'error' => $e->getMessage()      // ← SMTP の詳細がそのまま出る
], 500);
```

SMTP 例外にはホスト名・ポート・認証方式・認証失敗の理由が含まれます。詳細は `Log::error` に送り、レスポンスには追跡用の `error_id` だけ返すようにしました。

### 併せて修正：入力が一切検証されていなかった

```php
$mailData = [
    'title' => $request->title,      // 検証なし
    'body'  => $request->body,       // 検証なし
    'name'  => $request->name,       // 検証なし
];
Mail::to($request->recipient_email)  // 検証なし
```

特に `recipient_email` は**任意のアドレスを指定できる**ため、このエンドポイントがオープンリレーとして悪用できる状態でした。攻撃者は本文と宛先を自由に指定して、あなたのドメインの信用でスパムを送れます。

`email:rfc` と長さ上限を追加し、宛先は本来サーバ側で決めるべき値であることをコメントに明記しました。`title` / `body` / `name` も無制限だったため上限を設定しています。

## 3. `Controller.php`

```php
throw new DatabaseOperationException(
    "データベース操作でエラーが発生しました: " . $e->getMessage(),
    0,
    $e
);
```

`PDOException` のメッセージにはクエリ本文やテーブル名が含まれることがあり、この例外がそのまま画面や API レスポンスへ出ると内部構造が漏れます。

連結をやめました。**追跡性は落ちません** — 詳細は直前の `Log::error` に残っており、元の例外も `$previous` として保持されています。2 箇所とも修正しました。

## 確認

```
$ php -l Controller.php database.php Mailble/MailController.php
No syntax errors detected
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0168HSPWgAAvWaQvfZEkbkdT)_